### PR TITLE
(fix) Enabled the Cell component properly react to color changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,6 @@
 
 ### QA steps
 
-Preview URL: <branch-name>.pixel-art-8rh.pages.dev
+Preview URL: https://<branch-name>.pixel-art-8rh.pages.dev
 
 1. How to QA this PR.

--- a/src/components/Cell.vue
+++ b/src/components/Cell.vue
@@ -12,6 +12,7 @@ const props = defineProps({
 
 const emit = defineEmits(['update'])
 
+// Dropdown objects.  Maybe this should move to the database.
 const validColors = ref([
   { name: 'White', color: '#FFFFFF' },
   { name: 'Blue', color: '#0000FF' },
@@ -21,7 +22,8 @@ const validColors = ref([
   { name: 'Purple', color: '#800080' },
 ])
 
-const selectedColor = ref(validColors.value.find(item => item.color === props.color) || validColors.value[0])
+// Figure out what the initial dropdown value is
+const selectedColor = ref(determineValidColor(props.color))
 const op = ref();
 const cellBorder = ref('unset')
 
@@ -29,18 +31,29 @@ const toggle = (event) => {
   op.value.toggle(event);
 }
 
+// When the Overlay Panel closes, remove the cell border highlight
 const opClosed = () => {
-  console.log('op closed')
   cellBorder.value = 'unset'
 }
 
+// When the Overlay Panel opens, highlight the cell with a border change
 const opOpened = () => {
-  console.log('op opened')
   cellBorder.value = 'solid grey'
 }
 
+function determineValidColor(color) {
+  return validColors.value.find(item => item.color === color) || validColors.value[0]
+}
+
+// Watch the prop.color and update the dropdown selection when it changes
+watch(() => props.color, (newColor, oldColor) => {
+  // console.log('watch props.color', newColor, oldColor)
+  selectedColor.value = determineValidColor(newColor)
+})
+
+// Emit the update event when the dropdown changes its selection
 watch(selectedColor, (newSelectedColor, oldSelectedColor) => {
-  console.log(`the cell color changed to ${newSelectedColor.name}`)
+  // console.log(`the cell color changed to ${newSelectedColor.name}`)
   emit('update', { row: props.row, col: props.col, color: newSelectedColor.color })
 })
 </script>


### PR DESCRIPTION
### Description

Added a watcher to the Cell components color prop.  This allows the component to be able to react to the prop changes and update the value selected by the dropdown.

### QA steps

Preview URL: https://fix-dropdown-selection.pixel-art-8rh.pages.dev

1. Navigate to: https://pixel-art.davefollett.dev
2. Verify that when a cell is clicked, the dropdown does NOT show the proper value.

   
   <img width="602" alt="Screenshot 2024-01-15 at 10 16 13 PM" src="https://github.com/OnCode9/pixel-art/assets/6683520/a0b6dc09-059e-4d9a-bc0d-9b304f6cc7b8">

3. Navigate to: https://fix-dropdown-selection.pixel-art-8rh.pages.dev
4. Verify that when a cell is clicked, the dropdown shows the proper value.

   <img width="629" alt="Screenshot 2024-01-15 at 10 19 07 PM" src="https://github.com/OnCode9/pixel-art/assets/6683520/ec56f8c4-713a-402a-af42-dd12a04a3966">


